### PR TITLE
Potential fix for code scanning alert no. 5: Unsafe jQuery plugin

### DIFF
--- a/InsureAnts/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/InsureAnts/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1083,7 +1083,7 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			return $.find( element ).not( this.settings.ignore )[ 0 ];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/Tea1810/InsureAnts/security/code-scanning/5](https://github.com/Tea1810/InsureAnts/security/code-scanning/5)

To fix the problem, we need to ensure that any user-provided input used in jQuery selectors is properly sanitized to prevent XSS attacks. This can be achieved by using `jQuery.find` instead of `jQuery` to ensure the input is always treated as a CSS selector and not as HTML.

- Replace the use of `$(element)` with `$.find(element)` in the `validationTargetFor` function.
- Ensure that all other instances where user input is used in jQuery selectors are similarly sanitized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
