### PR TITLE
Potential fix for code scanning alert no. 3: Unsafe HTML constructed from library input

### DIFF
--- a/InsureAnts/wwwroot/lib/jquery/dist/jquery.js
+++ b/InsureAnts/wwwroot/lib/jquery/dist/jquery.js
@@ -1275,10 +1275,21 @@ function setDocument( node ) {
 
 		var input;
 
-		documentElement.appendChild( el ).innerHTML =
-			"<a id='" + expando + "' href='' disabled='disabled'></a>" +
-			"<select id='" + expando + "-\r\\' disabled='disabled'>" +
-			"<option selected=''></option></select>";
+		var anchor = document.createElement('a');
+		anchor.id = expando;
+		anchor.href = '';
+		anchor.disabled = true;
+		el.appendChild(anchor);
+
+		var select = document.createElement('select');
+		select.id = expando + "-\r\\";
+		select.disabled = true;
+
+		var option = document.createElement('option');
+		option.selected = true;
+		select.appendChild(option);
+
+		el.appendChild(select);
 
 		// Support: iOS <=7 - 8 only
 		// Boolean attributes and "value" are not treated correctly in some XML documents


### PR DESCRIPTION
Potential fix for [https://github.com/Tea1810/InsureAnts/security/code-scanning/3](https://github.com/Tea1810/InsureAnts/security/code-scanning/3)

To fix the problem, we need to ensure that the HTML construction using `innerHTML` is safe. This can be achieved by either sanitizing the input or using safer methods to construct the HTML. In this case, we will use the `createElement` and `appendChild` methods to construct the HTML elements safely.

- Replace the use of `innerHTML` with the creation of elements using `document.createElement` and appending them to the parent element.
- Ensure that the `expando` variable is used safely by setting it as an attribute rather than directly inserting it into the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
